### PR TITLE
Fix : Unused section var in CheckIfJsonKeyExists

### DIFF
--- a/utils.hpp
+++ b/utils.hpp
@@ -21,7 +21,7 @@ bool CheckIfJsonKeyExists(std::string path, std::string section)
 		return skCrypt("File Not Found").decrypt();
 	std::ifstream file(path);
 	json data = json::parse(file);
-	return data.contains("username");
+	return data.contains(section);
 }
 
 bool WriteToJson(std::string path, std::string name, std::string value, bool userpass, std::string name2, std::string value2) 


### PR DESCRIPTION
Unused variable 'section' in function ReadFromJson causes failure when 'section' is set anyting but "username"